### PR TITLE
Multimedia core bundle

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -123,7 +123,8 @@ class AppKernel extends Kernel
             new Sonata\TimelineBundle\SonataTimelineBundle(),
             new Application\Sonata\TimelineBundle\ApplicationSonataTimelineBundle(), // easy extends integration
 
-            new Mopa\Bundle\BootstrapBundle\MopaBootstrapBundle()
+            new Mopa\Bundle\BootstrapBundle\MopaBootstrapBundle(),
+            new Application\Multimedia\CoreBundle\MultimediaCoreBundle(),
         );
 
         if (in_array($this->getEnvironment(), array('dev', 'test'))) {

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -1,3 +1,8 @@
+multimedia_core:
+    resource: "@MultimediaCoreBundle/Controller/"
+    type:     annotation
+    prefix:   /
+
 # Internal routing configuration to handle ESI
 #_internal:
 #   resource: "@FrameworkBundle/Resources/config/routing/internal.xml"

--- a/src/Application/Multimedia/CoreBundle/Controller/DefaultController.php
+++ b/src/Application/Multimedia/CoreBundle/Controller/DefaultController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Application\Multimedia\CoreBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+
+class DefaultController extends Controller
+{
+    /**
+     * @Route("/hello/{name}")
+     * @Template()
+     */
+    public function indexAction($name)
+    {
+        return array('name' => $name);
+    }
+}

--- a/src/Application/Multimedia/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Application/Multimedia/CoreBundle/DependencyInjection/Configuration.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Application\Multimedia\CoreBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * This is the class that validates and merges configuration from your app/config files
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
+ */
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('multimedia_core');
+
+        // Here you should define the parameters that are allowed to
+        // configure your bundle. See the documentation linked above for
+        // more information on that topic.
+
+        return $treeBuilder;
+    }
+}

--- a/src/Application/Multimedia/CoreBundle/DependencyInjection/MultimediaCoreExtension.php
+++ b/src/Application/Multimedia/CoreBundle/DependencyInjection/MultimediaCoreExtension.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Application\Multimedia\CoreBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Loader;
+
+/**
+ * This is the class that loads and manages your bundle configuration
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
+ */
+class MultimediaCoreExtension extends Extension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.xml');
+    }
+}

--- a/src/Application/Multimedia/CoreBundle/MultimediaCoreBundle.php
+++ b/src/Application/Multimedia/CoreBundle/MultimediaCoreBundle.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Application\Multimedia\CoreBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class MultimediaCoreBundle extends Bundle
+{
+}

--- a/src/Application/Multimedia/CoreBundle/MultimediaCoreBundle.php
+++ b/src/Application/Multimedia/CoreBundle/MultimediaCoreBundle.php
@@ -6,4 +6,8 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class MultimediaCoreBundle extends Bundle
 {
+    public function getParent()
+    {
+        return 'ApplicationSonataPageBundle';
+    }
 }

--- a/src/Application/Multimedia/CoreBundle/Resources/config/services.xml
+++ b/src/Application/Multimedia/CoreBundle/Resources/config/services.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <!--
+    <services>
+        <service id="multimedia_core.example" class="Application\Multimedia\CoreBundle\Example">
+            <argument type="service" id="service_id" />
+            <argument>plain_value</argument>
+            <argument>%parameter_name%</argument>
+        </service>
+    </services>
+    -->
+</container>

--- a/src/Application/Multimedia/CoreBundle/Resources/views/Default/index.html.twig
+++ b/src/Application/Multimedia/CoreBundle/Resources/views/Default/index.html.twig
@@ -1,0 +1,1 @@
+Hello {{ name }}!

--- a/src/Application/Multimedia/CoreBundle/Tests/Controller/DefaultControllerTest.php
+++ b/src/Application/Multimedia/CoreBundle/Tests/Controller/DefaultControllerTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Application\Multimedia\CoreBundle\Tests\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class DefaultControllerTest extends WebTestCase
+{
+    public function testIndex()
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', '/hello/Fabien');
+
+        $this->assertTrue($crawler->filter('html:contains("Hello Fabien")')->count() > 0);
+    }
+}


### PR DESCRIPTION
This PR aims at adding the `Multimedia core bundle`.

```
> php app/console generate:bundle
Bundle namespace: Application/Multimedia/CoreBundle
Bundle name: MultimediaCoreBundle
Target directory: <default>
Configuration format: annotation
Do you want to generate the whole directory structure: no
Do you confirm generation: yes
Confirm automatic update of your Kernel: yes
Confirm automatic update of the Routing: yes
```

You can try `/hello/antonio` after running:

```
php app/console  sonata:page:update-core-routes --site=all
php app/console sonata:page:create-snapshots --site=all
```

In order to override parts of a Bundle you need to edit `src/Application/Multimedia/CoreBundle/MultimediaCoreBundle.php`

```
public function getParent()
{
    return 'ApplicationSonataPageBundle';
}
```

and then run the following command:

```
cp -r \
vendor/sonata-project/page-bundle/Resources/views \ 
src/Application/Multimedia/CoreBundle/Resources/ 
```
