### PR TITLE
MultimediaModelBundle

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -125,6 +125,7 @@ class AppKernel extends Kernel
 
             new Mopa\Bundle\BootstrapBundle\MopaBootstrapBundle(),
             new Application\Multimedia\CoreBundle\MultimediaCoreBundle(),
+            new Application\Multimedia\ModelBundle\MultimediaModelBundle(),
         );
 
         if (in_array($this->getEnvironment(), array('dev', 'test'))) {

--- a/app/DoctrineMigrations/Version20150325100150.php
+++ b/app/DoctrineMigrations/Version20150325100150.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20150325100150 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE customers (customer_id INT AUTO_INCREMENT NOT NULL, customer_name VARCHAR(100) DEFAULT NULL, PRIMARY KEY(customer_id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE orders (order_id INT AUTO_INCREMENT NOT NULL, customer_id INT DEFAULT NULL, amount DOUBLE PRECISION DEFAULT NULL, INDEX customer_id (customer_id), PRIMARY KEY(order_id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE orders ADD CONSTRAINT FK_E52FFDEE9395C3F3 FOREIGN KEY (customer_id) REFERENCES customers (customer_id)');
+        $this->addSql('ALTER TABLE order__order CHANGE currency currency CHAR(3) DEFAULT NULL');
+        $this->addSql('ALTER TABLE order__order_audit CHANGE currency currency CHAR(3) DEFAULT NULL');
+        $this->addSql('ALTER TABLE invoice__invoice CHANGE currency currency CHAR(3) NOT NULL');
+        $this->addSql('ALTER TABLE invoice__invoice_audit CHANGE currency currency CHAR(3) DEFAULT NULL');
+        $this->addSql('ALTER TABLE basket__basket CHANGE currency currency CHAR(3) DEFAULT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE orders DROP FOREIGN KEY FK_E52FFDEE9395C3F3');
+        $this->addSql('DROP TABLE customers');
+        $this->addSql('DROP TABLE orders');
+        $this->addSql('ALTER TABLE basket__basket CHANGE currency currency CHAR(3) DEFAULT NULL COLLATE utf8_unicode_ci');
+        $this->addSql('ALTER TABLE invoice__invoice CHANGE currency currency CHAR(3) NOT NULL COLLATE utf8_unicode_ci');
+        $this->addSql('ALTER TABLE invoice__invoice_audit CHANGE currency currency CHAR(3) DEFAULT NULL COLLATE utf8_unicode_ci');
+        $this->addSql('ALTER TABLE order__order CHANGE currency currency CHAR(3) DEFAULT NULL COLLATE utf8_unicode_ci');
+        $this->addSql('ALTER TABLE order__order_audit CHANGE currency currency CHAR(3) DEFAULT NULL COLLATE utf8_unicode_ci');
+    }
+}

--- a/src/Application/Multimedia/ModelBundle/DependencyInjection/Configuration.php
+++ b/src/Application/Multimedia/ModelBundle/DependencyInjection/Configuration.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Application\Multimedia\ModelBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * This is the class that validates and merges configuration from your app/config files
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
+ */
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('multimedia_model');
+
+        // Here you should define the parameters that are allowed to
+        // configure your bundle. See the documentation linked above for
+        // more information on that topic.
+
+        return $treeBuilder;
+    }
+}

--- a/src/Application/Multimedia/ModelBundle/DependencyInjection/MultimediaModelExtension.php
+++ b/src/Application/Multimedia/ModelBundle/DependencyInjection/MultimediaModelExtension.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Application\Multimedia\ModelBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Loader;
+
+/**
+ * This is the class that loads and manages your bundle configuration
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
+ */
+class MultimediaModelExtension extends Extension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.xml');
+    }
+}

--- a/src/Application/Multimedia/ModelBundle/Entity/Customers.php
+++ b/src/Application/Multimedia/ModelBundle/Entity/Customers.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Application\Multimedia\ModelBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Customers
+ */
+class Customers
+{
+    /**
+     * @var string
+     */
+    private $customerName;
+
+    /**
+     * @var integer
+     */
+    private $customerId;
+
+
+    /**
+     * Set customerName
+     *
+     * @param string $customerName
+     * @return Customers
+     */
+    public function setCustomerName($customerName)
+    {
+        $this->customerName = $customerName;
+
+        return $this;
+    }
+
+    /**
+     * Get customerName
+     *
+     * @return string 
+     */
+    public function getCustomerName()
+    {
+        return $this->customerName;
+    }
+
+    /**
+     * Get customerId
+     *
+     * @return integer 
+     */
+    public function getCustomerId()
+    {
+        return $this->customerId;
+    }
+}

--- a/src/Application/Multimedia/ModelBundle/Entity/Orders.php
+++ b/src/Application/Multimedia/ModelBundle/Entity/Orders.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Application\Multimedia\ModelBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Orders
+ */
+class Orders
+{
+    /**
+     * @var float
+     */
+    private $amount;
+
+    /**
+     * @var integer
+     */
+    private $orderId;
+
+    /**
+     * @var \Application\Multimedia\ModelBundle\Entity\Customers
+     */
+    private $customer;
+
+
+    /**
+     * Set amount
+     *
+     * @param float $amount
+     * @return Orders
+     */
+    public function setAmount($amount)
+    {
+        $this->amount = $amount;
+
+        return $this;
+    }
+
+    /**
+     * Get amount
+     *
+     * @return float 
+     */
+    public function getAmount()
+    {
+        return $this->amount;
+    }
+
+    /**
+     * Get orderId
+     *
+     * @return integer 
+     */
+    public function getOrderId()
+    {
+        return $this->orderId;
+    }
+
+    /**
+     * Set customer
+     *
+     * @param \Application\Multimedia\ModelBundle\Entity\Customers $customer
+     * @return Orders
+     */
+    public function setCustomer(\Application\Multimedia\ModelBundle\Entity\Customers $customer = null)
+    {
+        $this->customer = $customer;
+
+        return $this;
+    }
+
+    /**
+     * Get customer
+     *
+     * @return \Application\Multimedia\ModelBundle\Entity\Customers 
+     */
+    public function getCustomer()
+    {
+        return $this->customer;
+    }
+}

--- a/src/Application/Multimedia/ModelBundle/MultimediaModelBundle.php
+++ b/src/Application/Multimedia/ModelBundle/MultimediaModelBundle.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Application\Multimedia\ModelBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class MultimediaModelBundle extends Bundle
+{
+}

--- a/src/Application/Multimedia/ModelBundle/Resources/config/doctrine/Customers.orm.xml
+++ b/src/Application/Multimedia/ModelBundle/Resources/config/doctrine/Customers.orm.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+  <entity name="Application\Multimedia\ModelBundle\Entity\Customers" table="customers">
+    <id name="customerId" type="integer" column="customer_id">
+      <generator strategy="IDENTITY"/>
+    </id>
+    <field name="customerName" type="string" column="customer_name" length="100" nullable="true"/>
+  </entity>
+</doctrine-mapping>

--- a/src/Application/Multimedia/ModelBundle/Resources/config/doctrine/Orders.orm.xml
+++ b/src/Application/Multimedia/ModelBundle/Resources/config/doctrine/Orders.orm.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+  <entity name="Application\Multimedia\ModelBundle\Entity\Orders" table="orders">
+    <indexes>
+      <index name="customer_id" columns="customer_id"/>
+    </indexes>
+    <id name="orderId" type="integer" column="order_id">
+      <generator strategy="IDENTITY"/>
+    </id>
+    <field name="amount" type="float" column="amount" precision="10" scale="0" nullable="true"/>
+    <many-to-one field="customer" target-entity="Customers">
+      <join-columns>
+        <join-column name="customer_id" referenced-column-name="customer_id"/>
+      </join-columns>
+    </many-to-one>
+  </entity>
+</doctrine-mapping>

--- a/src/Application/Multimedia/ModelBundle/Resources/config/services.xml
+++ b/src/Application/Multimedia/ModelBundle/Resources/config/services.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <!--
+    <services>
+        <service id="multimedia_model.example" class="Application\Multimedia\ModelBundle\Example">
+            <argument type="service" id="service_id" />
+            <argument>plain_value</argument>
+            <argument>%parameter_name%</argument>
+        </service>
+    </services>
+    -->
+</container>

--- a/src/Application/Multimedia/ModelBundle/Tests/Controller/DefaultControllerTest.php
+++ b/src/Application/Multimedia/ModelBundle/Tests/Controller/DefaultControllerTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Application\Multimedia\ModelBundle\Tests\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class DefaultControllerTest extends WebTestCase
+{
+    public function testIndex()
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', '/hello/Fabien');
+
+        $this->assertTrue($crawler->filter('html:contains("Hello Fabien")')->count() > 0);
+    }
+}


### PR DESCRIPTION
This PR aims at adding the Multimedia Model Bundle, the layer which interacts with the database.
We don't need router because it does not have to respond to any http request.

```
> php app/console generate:bundle
Bundle namespace: Application/Multimedia/ModelBundle
Bundle name: MultimediaModelBundle
Target directory: <default>
Configuration format: annotation
Do you want to generate the whole directory structure: no
Do you confirm generation: yes
Confirm automatic update of your Kernel: yes
Confirm automatic update of the Routing: no
```

You can delete the `ModelBundle/Controller` and `Resources/views`
##### Generate Entities from an Existing Database

Let's create a database with the the following relationships (database should be different from the configured db):

```
-- A very simple database to hold book and author information
CREATE TABLE book (
       id          INTEGER PRIMARY KEY,
       title       TEXT ,
       rating      INTEGER
);
-- 'book_author' is a many-to-many join table between books & authors
CREATE TABLE book_author (
       book_id     INTEGER,
       author_id   INTEGER,
       PRIMARY KEY (book_id, author_id),
       CONSTRAINT fk_book FOREIGN KEY (book_id) REFERENCES book(id),
       CONSTRAINT fk_author FOREIGN KEY (author_id) REFERENCES author(id)
);
CREATE TABLE author (
       id          INTEGER PRIMARY KEY,
       first_name  TEXT,
       last_name   TEXT
);
```

Let's ask Doctrine to introspect the database and generate the corresponding metadata files (remember to change the db parameter):

```
> php app/console doctrine:mapping:import --force MultimediaModelBundle xml
```

 Let's ask Doctrine to build related entity classes by executing the following two commands:

```
> php app/console doctrine:generate:entities MultimediaModelBundle
```
##### Database migration:

If you reset the db parameters `book` table does not exist:

```
mysql> select * from book;
ERROR 1146 (42S02): Table 're_db.book' doesn't exist

> php app/console doctrine:migrations:diff
> php app/console doctrine:migrations:status --show-versions
> php app/console doctrine:migrations:migrate 20150325094851 

mysql> select * from customers;
Empty set (0.00 sec)

> php app/console doctrine:migrations:migrate  prev # rollback is an operation 
# which returns the database to some previous state

mysql> select * from book;
ERROR 1146 (42S02): Table 're_db.book' doesn't exist

> php app/console doctrine:migrations:migrate 20150325094851
```
#### References:

[Reverse Engineering](http://symfony.com/doc/current/cookbook/doctrine/reverse_engineering.html)
