### PR TITLE
Adding a tree-view to manage the books

### DIFF
--- a/app/config/sonata/sonata_admin.yml
+++ b/app/config/sonata/sonata_admin.yml
@@ -106,6 +106,15 @@ sonata_admin:
                     - sonata.demo.admin.color
                     - sonata.demo.admin.material
 
+            sonata.admin.group.books:
+                label:           Books
+                icon:  '<i class="fa fa-play-circle"></i>'
+                label_catalogue: MultimediaCoreBundle
+                items:
+                    - multimedia_core.admin.book
+                    - multimedia.admin.author
+                    - multimedia.admin.book_author
+
     assets:
         stylesheets:
             # The sandbox includes default pre-optimized version of some css and js


### PR DESCRIPTION
This PR aims at adding a tree-view item to manage the books entities.
##### Procedure
1. Edit the file `./app/config/sonata/sonata_admin.yml` and add the following line to the `sonata_admin:dashboard:group block`
   
   ```
       sonata.admin.group.books:
           label:           Books
           icon:  '<i class="fa fa-play-circle"></i>'
           label_catalogue: MultimediaCoreBundle
           items:
               - multimedia_core.admin.book
               - multimedia.admin.author
               - multimedia.admin.book_author
   ```
   
   You can take the items running the command `php app/console sonata:admin:list`
